### PR TITLE
Display request fields dynamically

### DIFF
--- a/app/Http/Controllers/OcdRequestController.php
+++ b/app/Http/Controllers/OcdRequestController.php
@@ -10,7 +10,7 @@ use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
 
-class RequestController extends Controller
+class OcdRequestController extends Controller
 {
 
 
@@ -160,9 +160,9 @@ class RequestController extends Controller
     /**
      * Display the specified resource.
      */
-    public function show(int $OCDrequestId)
+    public function show(Request $httpRequest, int $OCDrequestId)
     {
-        $ocdRequest = OCDRequest::with('status')->find($OCDrequestId);
+        $ocdRequest = OCDRequest::with(['status', 'user'])->find($OCDrequestId);
         if (!$ocdRequest) {
             return response()->json(['error' => 'Ocd Request not found'], 404);
         }
@@ -179,6 +179,13 @@ class RequestController extends Controller
                 ['name' => 'Dashboard', 'url' => route('dashboard')],
                 ['name' => 'Requests', 'url' => route('user.request.myrequests')],
                 ['name' => 'View Request #' . $ocdRequest->id, 'url' => route('partner.opportunity.show', ['id' => $ocdRequest->id])],
+            ],
+            'requestDetail.actions' => [
+                'canEdit' => $ocdRequest->user->id === $httpRequest->user()->id && $ocdRequest->status->status_code === "draft",
+                'canDelete' => $ocdRequest->user->id === $httpRequest->user()->id && $ocdRequest->status->status_code === "draft",
+                'canCreate' => false,
+                'canExpressInterrest' => $ocdRequest->user->id !== $httpRequest->user()->id,
+                'canExportPdf' => true
             ],
         ]);
     }

--- a/resources/js/Pages/Request/Show.tsx
+++ b/resources/js/Pages/Request/Show.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Head, usePage, Link } from '@inertiajs/react';
 import FrontendLayout from '@/Layouts/FrontendLayout';
 import { OCDRequest } from '@/types';
+import { UIRequestForm } from '@/Forms/UIRequestForm';
 
 
 export default function ShowRequest() {
@@ -17,83 +18,45 @@ export default function ShowRequest() {
         <div className="col-span-2">
           <div className="max-w-screen-xl mx-auto px-5 bg-white min-h-sceen">
             <div className="grid divide-y divide-neutral-200 mx-auto">
-              <div className="py-5">
-                <details className="group">
-                  <summary className="flex justify-between items-center font-medium cursor-pointer list-none">
-                    <span> Details</span>
-                    <span className="transition group-open:rotate-180">
-                      <svg fill="none" height="24" shapeRendering="geometricPrecision" stroke="currentColor" stroke-linecap="round" strokeLinejoin="round" strokeWidth="1.5" viewBox="0 0 24 24" width="24"><path d="M6 9l6 6 6-6"></path>
-                      </svg>
-                    </span>
-                  </summary>
-                  <ul className="text-neutral-600 mt-3 group-open:animate-fadeIn list-disc">
-                    <li>
-                      We offers a 30-day money-back guarantee for most of its subscription plans. If you are not
-                      satisfied with your subscription within the first 30 days, you can request a full refund. Refunds
-                      for subscriptions that have been active for longer than 30 days may be considered on a case-by-case
-                      basis.
-                    </li><li>
-                      We offers a 30-day money-back guarantee for most of its subscription plans. If you are not
-                      satisfied with your subscription within the first 30 days, you can request a full refund. Refunds
-                      for subscriptions that have been active for longer than 30 days may be considered on a case-by-case
-                      basis.
-                    </li><li>
-                      We offers a 30-day money-back guarantee for most of its subscription plans. If you are not
-                      satisfied with your subscription within the first 30 days, you can request a full refund. Refunds
-                      for subscriptions that have been active for longer than 30 days may be considered on a case-by-case
-                      basis.
-                    </li>
-                  </ul>
-                </details>
-              </div>
-              <div className="py-5">
-                <details className="group">
-                  <summary className="flex justify-between items-center font-medium cursor-pointer list-none">
-                    <span>Capacity & Partners</span>
-                    <span className="transition group-open:rotate-180">
-                      <svg fill="none" height="24" shapeRendering="geometricPrecision" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" strokeWidth="1.5" viewBox="0 0 24 24" width="24"><path d="M6 9l6 6 6-6"></path>
-                      </svg>
-                    </span>
-                  </summary>
-                  <p className="text-neutral-600 mt-3 group-open:animate-fadeIn">
-                    To cancel your We subscription, you can log in to your account and navigate to the
-                    subscription management page. From there, you should be able to cancel your subscription and stop
-                    future billing.
-                  </p>
-                </details>
-              </div>
-              <div className="py-5">
-                <details className="group">
-                  <summary className="flex justify-between items-center font-medium cursor-pointer list-none">
-                    <span>Service</span>
-                    <span className="transition group-open:rotate-180">
-                      <svg fill="none" height="24" shapeRendering="geometricPrecision" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" strokeWidth="1.5" viewBox="0 0 24 24" width="24"><path d="M6 9l6 6 6-6"></path>
-                      </svg>
-                    </span>
-                  </summary>
-                  <p className="text-neutral-600 mt-3 group-open:animate-fadeIn">
-                    To cancel your We subscription, you can log in to your account and navigate to the
-                    subscription management page. From there, you should be able to cancel your subscription and stop
-                    future billing.
-                  </p>
-                </details>
-              </div>
-              <div className="py-5">
-                <details className="group">
-                  <summary className="flex justify-between items-center font-medium cursor-pointer list-none">
-                    <span>Risks</span>
-                    <span className="transition group-open:rotate-180">
-                      <svg fill="none" height="24" shapeRendering="geometricPrecision" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" strokeWidth="1.5" viewBox="0 0 24 24" width="24"><path d="M6 9l6 6 6-6"></path>
-                      </svg>
-                    </span>
-                  </summary>
-                  <p className="text-neutral-600 mt-3 group-open:animate-fadeIn">
-                    To cancel your We subscription, you can log in to your account and navigate to the
-                    subscription management page. From there, you should be able to cancel your subscription and stop
-                    future billing.
-                  </p>
-                </details>
-              </div>
+              {UIRequestForm.map(step => (
+                <div className="py-5" key={step.label}>
+                  <details className="group">
+                    <summary className="flex justify-between items-center font-medium cursor-pointer list-none">
+                      <span>{step.label}</span>
+                      <span className="transition group-open:rotate-180">
+                        <svg
+                          fill="none"
+                          height="24"
+                          shapeRendering="geometricPrecision"
+                          stroke="currentColor"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth="1.5"
+                          viewBox="0 0 24 24"
+                          width="24"
+                        >
+                          <path d="M6 9l6 6 6-6"></path>
+                        </svg>
+                      </span>
+                    </summary>
+                    <ul className="text-neutral-600 mt-3 group-open:animate-fadeIn list-disc">
+                      {Object.entries(step.fields).map(([key, field]) => {
+                        if (!field.label || field.type === 'hidden') return null;
+                        if (field.show && !field.show(OcdRequest.request_data)) return null;
+                        const value = (OcdRequest.request_data as any)[key];
+                        if (value === undefined || value === '') return null;
+                        const formatted = Array.isArray(value) ? value.join(', ') : value;
+                        return (
+                          <li key={key}>
+                            <span className="font-medium">{field.label}: </span>
+                            {formatted}
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </details>
+                </div>
+              ))}
             </div>
           </div>
         </div>

--- a/resources/js/Pages/Request/Show.tsx
+++ b/resources/js/Pages/Request/Show.tsx
@@ -2,12 +2,14 @@
 import React from 'react';
 import { Head, usePage, Link } from '@inertiajs/react';
 import FrontendLayout from '@/Layouts/FrontendLayout';
-import { OCDRequest } from '@/types';
+import { OCDRequest, OCDRequestGrid } from '@/types';
 import { UIRequestForm } from '@/Forms/UIRequestForm';
 
 
 export default function ShowRequest() {
   const OcdRequest = usePage().props.request as OCDRequest;
+  const RequestDetails = usePage().props.requestDetail as OCDRequestGrid;
+
 
   return (
     <FrontendLayout>
@@ -21,8 +23,8 @@ export default function ShowRequest() {
               {UIRequestForm.map(step => (
                 <div className="py-5" key={step.label}>
                   <details className="group">
-                    <summary className="flex justify-between items-center font-medium cursor-pointer list-none">
-                      <span>{step.label}</span>
+                    <summary className="flex justify-between items-center cursor-pointer list-none">
+                      <span className="text-2xl text-firefly-800">{step.label}</span>
                       <span className="transition group-open:rotate-180">
                         <svg
                           fill="none"
@@ -39,7 +41,7 @@ export default function ShowRequest() {
                         </svg>
                       </span>
                     </summary>
-                    <ul className="text-neutral-600 mt-3 group-open:animate-fadeIn list-disc">
+                    <ul className=" group-open:animate-fadeIn list-none">
                       {Object.entries(step.fields).map(([key, field]) => {
                         if (!field.label || field.type === 'hidden') return null;
                         if (field.show && !field.show(OcdRequest.request_data)) return null;
@@ -47,9 +49,9 @@ export default function ShowRequest() {
                         if (value === undefined || value === '') return null;
                         const formatted = Array.isArray(value) ? value.join(', ') : value;
                         return (
-                          <li key={key}>
-                            <span className="font-medium">{field.label}: </span>
-                            {formatted}
+                          <li key={key} className='py-2 text-xl'>
+                            <span className="text-firefly-600">{field.label}: </span> <br />
+                            {formatted ?? 'N/A'}
                           </li>
                         );
                       })}
@@ -61,36 +63,39 @@ export default function ShowRequest() {
           </div>
         </div>
         <div>
-          <div>
-            <h2 className="text-xl font-semibold text-gray-500">Submission Date</h2>
-            <p className="mt-1 text-lg text-gray-900">
+          <div className='py-2'>
+            <h2 className="text-2xl text-firefly-800">Submission Date</h2>
+            <p className="mt-1 text-xl text-gray-900">
               {new Date(OcdRequest.created_at).toLocaleDateString()}
             </p>
           </div>
-
           <div>
-            <h2 className="text-xl font-semibold text-gray-500">Partner?</h2>
-            <p className="mt-1 text-gray-900">{OcdRequest.request_data.is_partner}</p>
-          </div>
-          {OcdRequest.request_data.is_partner === 'Yes' && (
-            <div>
-              <h2 className="text-xl font-semibold text-gray-500">Unique Partner ID</h2>
-              <p className="mt-1 text-gray-900">{OcdRequest.request_data.unique_id}</p>
-            </div>
-          )}
-          <div>
-            <h2 className="text-xl font-semibold text-gray-500">Name</h2>
-            <p className="mt-1 text-gray-900">
-              {OcdRequest.request_data.first_name} {OcdRequest.request_data.last_name}
+            <h2 className="text-2xl text-firefly-800">Status</h2>
+            <p className="mt-1 text-xl text-gray-900">
+              {OcdRequest.status.status_label}
             </p>
-          </div>
-          <div>
-            <h2 className="text-xl font-semibold text-gray-500">Email</h2>
-            <p className="mt-1 text-gray-900">{OcdRequest.request_data.email}</p>
           </div>
         </div>
 
       </div>
+
+      <section id="offer_container" className='container'>
+        <div className='row-span-full
+'>
+          <table className="table-auto w-full">
+            <thead>
+              <tr>
+                <th>Attachement Type</th>
+                <th>File name</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+            </tbody>
+          </table>u
+        </div>
+
+      </section>
 
 
 
@@ -100,12 +105,43 @@ export default function ShowRequest() {
 
       {/* Actions */}
       <div className="mt-8 flex space-x-4">
-        <Link
-          href={route('user.request.myrequests')}
-          className="px-4 py-2 bg-gray-200 text-gray-800 rounded hover:bg-gray-300"
-        >
-          Export the Request as PDF
-        </Link>
+
+        {RequestDetails.actions.canExportPdf && (
+          <Link
+            href={route('user.request.myrequests')}
+            className="px-4 py-2 bg-gray-200 text-gray-800 rounded hover:bg-gray-300"
+          >
+            Export the Request as PDF
+          </Link>
+        )}
+
+        {RequestDetails.actions.canEdit && (
+          <Link
+            href={route('user.request.myrequests')}
+            className="px-4 py-2 bg-gray-200 text-gray-800 rounded hover:bg-gray-300"
+          >
+            Edit
+          </Link>
+        )}
+
+        {RequestDetails.actions.canDelete && (
+          <Link
+            href={route('user.request.myrequests')}
+            className="px-4 py-2 bg-gray-200 text-gray-800 rounded hover:bg-gray-300"
+          >
+            Delete
+          </Link>
+        )}
+
+        {RequestDetails.actions.canDelete && (
+          <Link
+            href={route('user.request.myrequests')}
+            className="px-4 py-2 bg-gray-200 text-gray-800 rounded hover:bg-gray-300"
+          >
+            Delete
+          </Link>
+        )}
+
       </div>
     </FrontendLayout>
   );

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -135,7 +135,8 @@ export type OCDRequestGrid = {
         canEdit: boolean;
         canDelete: boolean;
         canView: boolean;
-        canCreate: boolean;
-        canExpressInterrest: boolean;
+        canCreate?: boolean;
+        canExpressInterrest?: boolean;
+        canExportPdf?:boolean;
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Dashboard\IndexController;
-use App\Http\Controllers\RequestController;
+use App\Http\Controllers\OcdRequestController;
 use Inertia\Inertia;
 use App\Http\Controllers\Partner\OpportunityController as PartnerOpportunityController;
 use App\Http\Controllers\User\OpportunityController as UserOpportunityController;
@@ -43,11 +43,11 @@ Route::get('user-guide', [UserGuideController::class, 'download'])->name('user.g
 Route::middleware(['auth', 'role:user'])->group(function () {
 
     Route::get('dashboard', IndexController::class)->name('dashboard');
-    Route::get('user/request/create', [RequestController::class, 'create'])->name('user.request.create');
-    Route::get('user/request/myrequests', [RequestController::class, 'myRequestsList'])->name('user.request.myrequests');
-    Route::get('user/request/edit/{id}', [RequestController::class, 'edit'])->name('user.request.edit');
-    Route::get('user/request/show/{id}', [RequestController::class, 'show'])->name('user.request.show');
-    Route::post('user/request/submit/{mode?}', [RequestController::class, 'submit'])->name('user.request.submit');
+    Route::get('user/request/create', [OcdRequestController::class, 'create'])->name('user.request.create');
+    Route::get('user/request/myrequests', [OcdRequestController::class, 'myRequestsList'])->name('user.request.myrequests');
+    Route::get('user/request/edit/{id}', [OcdRequestController::class, 'edit'])->name('user.request.edit');
+    Route::get('user/request/show/{id}', [OcdRequestController::class, 'show'])->name('user.request.show');
+    Route::post('user/request/submit/{mode?}', [OcdRequestController::class, 'submit'])->name('user.request.submit');
     Route::get('user/opportunity/list', [UserOpportunityController::class, 'list'])->name('user.opportunity.list');
     Route::get('user/opportunity/show/{id}', [UserOpportunityController::class, 'show'])->name('user.opportunity.show');
 });
@@ -59,8 +59,8 @@ Route::middleware(['auth', 'role:partner'])->group(function () {
     Route::post('partner/opportunity/store', [PartnerOpportunityController::class, 'store'])->name('partner.opportunity.store');
     Route::get('partner/opportunity/list', [PartnerOpportunityController::class, 'list'])->name('partner.opportunity.list');
     Route::get('partner/opportunity/show/{id}', [PartnerOpportunityController::class, 'show'])->name('partner.opportunity.show');
-    Route::get('partner/request/list', [RequestController::class, 'list'])->name('partner.request.list');
-    Route::get('partner/request/matchedrequests', [RequestController::class, 'matchedRequest'])->name('partner.request.matchedrequests');
+    Route::get('partner/request/list', [OcdRequestController::class, 'list'])->name('partner.request.list');
+    Route::get('partner/request/matchedrequests', [OcdRequestController::class, 'matchedRequest'])->name('partner.request.matchedrequests');
 });
 
 


### PR DESCRIPTION
## Summary
- map over `UIRequestForm` steps in request show page
- render each step's field labels and values

## Testing
- `npm run build` *(fails: Cannot find module '@inertiajs/react' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684246e71de4832e9bf872a4035c4719