### PR TITLE
Display request fields dynamically

### DIFF
--- a/app/Http/Controllers/DocumentController.php
+++ b/app/Http/Controllers/DocumentController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Document;
+use App\Models\Request as OCDRequest;
+use Illuminate\Http\Request as HttpRequest;
+use Illuminate\Support\Facades\Storage;
+
+class DocumentController extends Controller
+{
+    public function store(HttpRequest $httpRequest, OCDRequest $request)
+    {
+        $validated = $httpRequest->validate([
+            'document_type' => 'required|in:financial_breakdown_report,lesson_learned_report,offer_document',
+            'file' => 'required|file',
+        ]);
+
+        $path = $httpRequest->file('file')->store('documents', 'public');
+
+        Document::create([
+            'name' => $httpRequest->file('file')->getClientOriginalName(),
+            'path' => $path,
+            'file_type' => $httpRequest->file('file')->getClientMimeType(),
+            'document_type' => $validated['document_type'],
+            'parent_id' => $request->id,
+            'parent_type' => OCDRequest::class,
+            'uploader_id' => $httpRequest->user()->id,
+        ]);
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/OcdRequestController.php
+++ b/app/Http/Controllers/OcdRequestController.php
@@ -167,6 +167,10 @@ class OcdRequestController extends Controller
             return response()->json(['error' => 'Ocd Request not found'], 404);
         }
 
+        $documents = \App\Models\Document::where('parent_type', OCDRequest::class)
+            ->where('parent_id', $OCDrequestId)
+            ->get();
+
         return Inertia::render('Request/Show', [
             'title' => 'Request #' . $OCDrequestId,
             'banner' => [
@@ -175,6 +179,7 @@ class OcdRequestController extends Controller
                 'image' => '/assets/img/sidebar.png',
             ],
             'request' => $ocdRequest->toArray(),
+            'documents' => $documents,
             'breadcrumbs' => [
                 ['name' => 'Dashboard', 'url' => route('dashboard')],
                 ['name' => 'Requests', 'url' => route('user.request.myrequests')],

--- a/app/Models/Document.php
+++ b/app/Models/Document.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class Document extends Model
+{
+    protected $fillable = [
+        'name',
+        'path',
+        'file_type',
+        'document_type',
+        'parent_id',
+        'parent_type',
+        'uploader_id',
+    ];
+
+    public function parent(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    public function uploader(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'uploader_id');
+    }
+}

--- a/resources/js/Pages/Request/Show.tsx
+++ b/resources/js/Pages/Request/Show.tsx
@@ -1,13 +1,18 @@
 // resources/js/Pages/Requests/Show.tsx
-import React from 'react';
-import { Head, usePage, Link } from '@inertiajs/react';
+import React, { useState } from 'react';
+import { Head, usePage, Link, useForm } from '@inertiajs/react';
 import FrontendLayout from '@/Layouts/FrontendLayout';
-import { OCDRequest, OCDRequestGrid } from '@/types';
+import { OCDRequest, OCDRequestGrid , DocumentList } from '@/types';
 import { UIRequestForm } from '@/Forms/UIRequestForm';
 
 
 export default function ShowRequest() {
   const OcdRequest = usePage().props.request as OCDRequest;
+  const documents = usePage().props.documents as DocumentList;
+  const form = useForm<{ file: File | null; document_type: string }>({
+    file: null,
+    document_type: 'financial_breakdown_report',
+  });
   const RequestDetails = usePage().props.requestDetail as OCDRequestGrid;
 
 
@@ -23,7 +28,7 @@ export default function ShowRequest() {
               {UIRequestForm.map(step => (
                 <div className="py-5" key={step.label}>
                   <details className="group">
-                    <summary className="flex justify-between items-center cursor-pointer list-none">
+                    <summary className="flex justify-between items-center font-medium cursor-pointer list-none">
                       <span className="text-2xl text-firefly-800">{step.label}</span>
                       <span className="transition group-open:rotate-180">
                         <svg
@@ -60,6 +65,66 @@ export default function ShowRequest() {
                 </div>
               ))}
             </div>
+          </div>
+          <div className="mt-6">
+            <h2 className="text-xl font-semibold text-gray-500 mb-2">Attachments</h2>
+            <form
+              onSubmit={e => {
+                e.preventDefault();
+                form.post(route('user.request.document.store', { request: OcdRequest.id }), {
+                  forceFormData: true,
+                  onSuccess: () => form.reset(),
+                });
+              }}
+            >
+              <div className="flex space-x-4 items-end">
+                <select
+                  className="border rounded px-2 py-1"
+                  value={form.data.document_type}
+                  onChange={e => form.setData('document_type', e.currentTarget.value)}
+                >
+                  <option value="financial_breakdown_report">Financial Breakdown Report</option>
+                  <option value="lesson_learned_report">Lesson Learned Report</option>
+                  <option value="offer_document">Offer Document</option>
+                </select>
+                <input
+                  type="file"
+                  className="border rounded px-2 py-1"
+                  onChange={e => form.setData('file', e.currentTarget.files ? e.currentTarget.files[0] : null)}
+                />
+                <button
+                  type="submit"
+                  className="px-4 py-1 bg-firefly-600 text-white rounded disabled:opacity-50"
+                  disabled={form.processing || !form.data.file}
+                >
+                  Upload
+                </button>
+              </div>
+            </form>
+            {documents.length > 0 && (
+              <table className="mt-4 w-full text-left border">
+                <thead>
+                  <tr className="bg-gray-100">
+                    <th className="p-2">Name</th>
+                    <th className="p-2">Type</th>
+                    <th className="p-2">Uploaded At</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {documents.map(doc => (
+                    <tr key={doc.id} className="border-t">
+                      <td className="p-2">
+                        <a href={`/storage/${doc.path}`} className="text-blue-600 underline">
+                          {doc.name}
+                        </a>
+                      </td>
+                      <td className="p-2">{doc.document_type}</td>
+                      <td className="p-2">{new Date(doc.created_at).toLocaleDateString()}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
           </div>
         </div>
         <div>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -53,6 +53,21 @@ export interface OCDMetrics {
     number_of_open_partner_opertunities: number;
 }
 
+export interface Document {
+    id: number;
+    name: string;
+    path: string;
+    file_type?: string;
+    document_type?: string;
+    parent_id?: number;
+    parent_type?: string;
+    uploader_id: number;
+    created_at: string;
+    updated_at: string;
+}
+
+export type DocumentList = Document[];
+
 export interface OCDRequest {
     id: string;
     type: string;

--- a/routes/web.php
+++ b/routes/web.php
@@ -48,6 +48,7 @@ Route::middleware(['auth', 'role:user'])->group(function () {
     Route::get('user/request/edit/{id}', [OcdRequestController::class, 'edit'])->name('user.request.edit');
     Route::get('user/request/show/{id}', [OcdRequestController::class, 'show'])->name('user.request.show');
     Route::post('user/request/submit/{mode?}', [OcdRequestController::class, 'submit'])->name('user.request.submit');
+    Route::post('user/request/{request}/document', [\App\Http\Controllers\DocumentController::class, 'store'])->name('user.request.document.store');
     Route::get('user/opportunity/list', [UserOpportunityController::class, 'list'])->name('user.opportunity.list');
     Route::get('user/opportunity/show/{id}', [UserOpportunityController::class, 'show'])->name('user.opportunity.show');
 });


### PR DESCRIPTION
## Summary
- map over `UIRequestForm` steps in request show page
- render each step's field labels and values
- allow uploading attachments with file type selection
- list uploaded documents for each request

## Testing
- `npm run build` *(fails: cannot find modules)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684246e71de4832e9bf872a4035c4719