### PR TITLE
Add user role management UI

### DIFF
--- a/app/Http/Controllers/Admin/UserRoleController.php
+++ b/app/Http/Controllers/Admin/UserRoleController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+use Spatie\Permission\Models\Role;
+
+class UserRoleController extends Controller
+{
+    public function index(): Response
+    {
+        return Inertia::render('Admin/User/List', [
+            'users' => User::with('roles')->get(),
+            'roles' => Role::all(),
+        ]);
+    }
+
+    public function update(Request $request, User $user)
+    {
+        $data = $request->validate([
+            'roles' => 'array',
+            'roles.*' => 'string',
+        ]);
+
+        $user->syncRoles($data['roles'] ?? []);
+
+        return response()->json([
+            'message' => 'Roles updated successfully',
+            'roles' => $user->roles->pluck('name'),
+        ]);
+    }
+}

--- a/resources/js/Components/UserNav.tsx
+++ b/resources/js/Components/UserNav.tsx
@@ -86,6 +86,15 @@ export default function UserDropdown() {
                         My Opportunties List
                     </Link>
                     )}
+                    {user.is_admin && (
+                    <Link
+                        href={route('admin.users.index')}
+                        className="block px-4 py-2 text-gray-700 hover:bg-gray-100"
+                        role="menuitem"
+                    >
+                        Manage User Roles
+                    </Link>
+                    )}
                     <form method="POST" onSubmit={handleSignOutFormSubmit}>
                         {/* Include CSRF token if needed */}
                         <button

--- a/resources/js/Pages/Admin/User/List.tsx
+++ b/resources/js/Pages/Admin/User/List.tsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import { Head, usePage } from '@inertiajs/react';
+import FrontendLayout from '@/Layouts/FrontendLayout';
+import axios from 'axios';
+import { Role, UserWithRoles } from '@/types';
+
+interface PageProps {
+    users: UserWithRoles[];
+    roles: Role[];
+}
+
+export default function UserRolesList() {
+    const { users, roles } = usePage<PageProps>().props;
+
+    const [userRoles, setUserRoles] = useState<Record<number, string[]>>(() => {
+        const map: Record<number, string[]> = {};
+        users.forEach((u) => {
+            map[u.id] = u.roles.map((r) => r.name);
+        });
+        return map;
+    });
+
+    const toggleRole = (userId: number, role: string) => {
+        const existing = userRoles[userId] || [];
+        const updated = existing.includes(role)
+            ? existing.filter((r) => r !== role)
+            : [...existing, role];
+        setUserRoles({ ...userRoles, [userId]: updated });
+        axios.post(route('admin.users.roles.update', userId), { roles: updated }).catch(() => {
+            setUserRoles({ ...userRoles, [userId]: existing });
+        });
+    };
+
+    return (
+        <FrontendLayout>
+            <Head title="Manage User Roles" />
+            <div className="overflow-x-auto">
+                <table className="min-w-full table-auto bg-white">
+                    <thead className="bg-gray-50">
+                        <tr>
+                            <th className="px-4 py-2 text-left text-xl font-medium text-gray-500 uppercase">ID</th>
+                            <th className="px-4 py-2 text-left text-xl font-medium text-gray-500 uppercase">Name</th>
+                            <th className="px-4 py-2 text-left text-xl font-medium text-gray-500 uppercase">Email</th>
+                            {roles.map((role) => (
+                                <th key={role.id} className="px-4 py-2 text-left text-xl font-medium text-gray-500 uppercase">
+                                    {role.name}
+                                </th>
+                            ))}
+                        </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-200">
+                        {users.map((user) => (
+                            <tr key={user.id} className="hover:bg-gray-100">
+                                <td className="px-4 py-2 whitespace-nowrap text-base text-gray-900">{user.id}</td>
+                                <td className="px-4 py-2 whitespace-nowrap text-base text-gray-900">{user.name}</td>
+                                <td className="px-4 py-2 whitespace-nowrap text-base text-gray-900">{user.email}</td>
+                                {roles.map((role) => (
+                                    <td key={role.id} className="px-4 py-2 text-center">
+                                        <input
+                                            type="checkbox"
+                                            checked={userRoles[user.id]?.includes(role.name)}
+                                            onChange={() => toggleRole(user.id, role.name)}
+                                        />
+                                    </td>
+                                ))}
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+        </FrontendLayout>
+    );
+}

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -11,6 +11,17 @@ export interface User {
     is_admin: boolean;
 }
 
+export interface Role {
+    id: number;
+    name: string;
+}
+
+export interface UserWithRoles extends User {
+    roles: Role[];
+}
+
+export type UserWithRolesList = UserWithRoles[];
+
 export interface Auth {
     user: User;
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Partner\OpportunityController as PartnerOpportunityCont
 use App\Http\Controllers\User\OpportunityController as UserOpportunityController;
 use App\Http\Controllers\Partner\OpportunityController;
 use App\Http\Controllers\UserGuideController;
+use App\Http\Controllers\Admin\UserRoleController;
 
 Route::get('/', function () {
     return Inertia::render('Index', [
@@ -62,6 +63,11 @@ Route::middleware(['auth', 'role:partner'])->group(function () {
     Route::get('partner/opportunity/show/{id}', [PartnerOpportunityController::class, 'show'])->name('partner.opportunity.show');
     Route::get('partner/request/list', [OcdRequestController::class, 'list'])->name('partner.request.list');
     Route::get('partner/request/matchedrequests', [OcdRequestController::class, 'matchedRequest'])->name('partner.request.matchedrequests');
+});
+
+Route::middleware(['auth', 'role:administrator'])->prefix('admin')->group(function () {
+    Route::get('users', [UserRoleController::class, 'index'])->name('admin.users.index');
+    Route::post('users/{user}/roles', [UserRoleController::class, 'update'])->name('admin.users.roles.update');
 });
 
 


### PR DESCRIPTION
## Summary
- add admin user role management controller
- list all users with roles and toggle roles
- expose admin users page via new routes
- show Manage User Roles link for admins
- define Role and UserWithRoles types

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843e707aed4832eaa83b89d5af8854f