### PR TITLE
Add request status update from list

### DIFF
--- a/app/Http/Controllers/OcdRequestController.php
+++ b/app/Http/Controllers/OcdRequestController.php
@@ -157,6 +157,26 @@ class OcdRequestController extends Controller
         }
     }
 
+    public function updateStatus(Request $httpRequest, int $requestId)
+    {
+        $statusCode = $httpRequest->input('status');
+        $ocdRequest = OCDRequest::find($requestId);
+        if (!$ocdRequest) {
+            return response()->json(['error' => 'Request not found'], 404);
+        }
+        $status = RequestStatus::where('status_code', $statusCode)->first();
+        if (!$status) {
+            return response()->json(['error' => 'Status not found'], 422);
+        }
+        $ocdRequest->status()->associate($status);
+        $ocdRequest->save();
+
+        return response()->json([
+            'message' => 'Status updated successfully',
+            'status' => $status->only(['status_code', 'status_label'])
+        ]);
+    }
+
     /**
      * Display the specified resource.
      */

--- a/routes/web.php
+++ b/routes/web.php
@@ -49,6 +49,7 @@ Route::middleware(['auth', 'role:user'])->group(function () {
     Route::get('user/request/edit/{id}', [OcdRequestController::class, 'edit'])->name('user.request.edit');
     Route::get('user/request/show/{id}', [OcdRequestController::class, 'show'])->name('user.request.show');
     Route::post('user/request/submit/{mode?}', [OcdRequestController::class, 'submit'])->name('user.request.submit');
+    Route::patch('user/request/{id}/status', [OcdRequestController::class, 'updateStatus'])->name('user.request.status');
     Route::post('user/request/{request}/document', [\App\Http\Controllers\DocumentController::class, 'store'])->name('user.request.document.store');
     Route::get('user/opportunity/list', [UserOpportunityController::class, 'list'])->name('user.opportunity.list');
     Route::get('user/opportunity/show/{id}', [UserOpportunityController::class, 'show'])->name('user.opportunity.show');


### PR DESCRIPTION
## Summary
- allow status updates for requests via new PATCH endpoint
- add dropdown in request list for status updates

## Testing
- `npm run build` *(fails: Cannot find module '@inertiajs/react' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684554b81a34832e98a8b3144e7127ca