### PR TITLE
Add validation for request creation

### DIFF
--- a/resources/js/Pages/Request/Create.tsx
+++ b/resources/js/Pages/Request/Create.tsx
@@ -103,8 +103,22 @@ export default function RequestForm() {
         }
       })
       .catch(function (responseXhr) {
-        setXhrDialogResponseType('error');
-        setXhrDialogResponseMessage(responseXhr.response?.data?.error || 'Something went wrong');
+        if (responseXhr.response?.status === 422) {
+          form.setError(responseXhr.response.data.errors);
+          const stepsWithError: number[] = [];
+          Object.keys(responseXhr.response.data.errors).forEach(field => {
+            const idx = UIRequestForm.findIndex(step => step.fields[field]);
+            if (idx !== -1 && !stepsWithError.includes(idx + 1)) {
+              stepsWithError.push(idx + 1);
+            }
+          });
+          setErrorSteps(stepsWithError);
+          setXhrDialogResponseType('error');
+          setXhrDialogResponseMessage('Please correct the highlighted errors.');
+        } else {
+          setXhrDialogResponseType('error');
+          setXhrDialogResponseMessage(responseXhr.response?.data?.error || 'Something went wrong');
+        }
       })
       .finally(() => {
         // window.history.replaceState(null, "Submit Request", "/request/create/" + form.data.id);


### PR DESCRIPTION
## Summary
- implement Laravel validation rules for OCD requests
- handle validation errors in request creation form

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847a7f73f14832eab9ff00159acf9c8