### PR TITLE
Add PDF export feature for requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "primereact": "^10.9.6",
         "react-tag-input": "^6.10.6",
         "react-youtube": "^10.1.0",
+        "jspdf": "^2.5.1",
         "tailwind-merge": "^3.3.0",
         "tailwindcss-animate": "^1.0.7"
     }


### PR DESCRIPTION
## Summary
- allow exporting request details to PDF using jsPDF
- add `jspdf` dependency

## Testing
- `composer test` *(fails: command not found)*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684846b33590832e8288778f17728c69