### PR TITLE
Implement offer submission

### DIFF
--- a/app/Http/Controllers/OcdRequestController.php
+++ b/app/Http/Controllers/OcdRequestController.php
@@ -236,6 +236,10 @@ class OcdRequestController extends Controller
         $documents = \App\Models\Document::where('parent_type', OCDRequest::class)
             ->where('parent_id', $OCDrequestId)
             ->get();
+
+        $offers = \App\Models\Request\RequestOffer::with('documents')
+            ->where('request_id', $OCDrequestId)
+            ->get();
         return Inertia::render('Request/Show', [
             'title' => 'Request : ' . $ocdRequest->request_data?->capacity_development_title ?? 'N/A',
             'banner' => [
@@ -245,6 +249,7 @@ class OcdRequestController extends Controller
             ],
             'request' => $ocdRequest->toArray(),
             'documents' => $documents,
+            'offers' => $offers,
             'breadcrumbs' => [
                 ['name' => 'Dashboard', 'url' => route('dashboard')],
                 ['name' => 'Requests', 'url' => route('user.request.myrequests')],

--- a/app/Http/Controllers/RequestOfferController.php
+++ b/app/Http/Controllers/RequestOfferController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Request as OCDRequest;
+use App\Models\Request\RequestOffer;
+use App\Models\Document;
+use Illuminate\Http\Request as HttpRequest;
+
+class RequestOfferController extends Controller
+{
+    public function store(HttpRequest $httpRequest, OCDRequest $request)
+    {
+        $validated = $httpRequest->validate([
+            'description' => 'required|string',
+            'partner_id' => 'required|exists:users,id',
+            'file' => 'required|file|mimes:pdf',
+        ]);
+
+        $offer = new RequestOffer();
+        $offer->description = $validated['description'];
+        $offer->matched_partner_id = $validated['partner_id'];
+        $offer->request_id = $request->id;
+        $offer->status = 1;
+        $offer->save();
+
+        $path = $httpRequest->file('file')->store('documents', 'public');
+
+        Document::create([
+            'name' => $httpRequest->file('file')->getClientOriginalName(),
+            'path' => $path,
+            'file_type' => $httpRequest->file('file')->getClientMimeType(),
+            'document_type' => 'offer_document',
+            'parent_id' => $offer->id,
+            'parent_type' => RequestOffer::class,
+            'uploader_id' => $httpRequest->user()->id,
+        ]);
+
+        return back();
+    }
+}

--- a/resources/js/Pages/Request/Components/OfferSection.tsx
+++ b/resources/js/Pages/Request/Components/OfferSection.tsx
@@ -1,11 +1,11 @@
-import { Head, usePage, Link, useForm } from '@inertiajs/react';
-import type { Auth } from '@/types';
-import { AttachementsProps } from '@/types';
+import { useForm } from '@inertiajs/react';
+import { OfferProps } from '@/types';
 
-export default function OfferSection({ OcdRequest, canEdit = false, documents = [] }: AttachementsProps) {
-    const form = useForm<{ file: File | null; document_type: string }>({
+export default function OfferSection({ OcdRequest, offers }: OfferProps) {
+    const form = useForm<{ description: string; partner_id: string; file: File | null }>({
+        description: '',
+        partner_id: '',
         file: null,
-        document_type: 'offer',
     });
     return (
         <section id="attachements">
@@ -17,6 +17,73 @@ export default function OfferSection({ OcdRequest, canEdit = false, documents = 
                 </div>
             </div>
             <div className="grid grid-cols-1">
+                <form
+                    onSubmit={e => {
+                        e.preventDefault();
+                        form.post(route('partner.request.offer.store', { request: OcdRequest.id }), {
+                            forceFormData: true,
+                            onSuccess: () => form.reset(),
+                        });
+                    }}
+                >
+                    <div className="flex flex-col space-y-2">
+                        <input
+                            type="text"
+                            className="border rounded px-2 py-1"
+                            placeholder="Partner ID"
+                            value={form.data.partner_id}
+                            onChange={e => form.setData('partner_id', e.currentTarget.value)}
+                        />
+                        <textarea
+                            className="border rounded px-2 py-1"
+                            placeholder="Description"
+                            value={form.data.description}
+                            onChange={e => form.setData('description', e.currentTarget.value)}
+                        />
+                        <input
+                            type="file"
+                            accept="application/pdf"
+                            className="border rounded px-2 py-1"
+                            onChange={e => form.setData('file', e.currentTarget.files ? e.currentTarget.files[0] : null)}
+                        />
+                        <button
+                            type="submit"
+                            className="px-4 py-1 bg-firefly-600 text-white rounded disabled:opacity-50"
+                            disabled={form.processing || !form.data.file || !form.data.partner_id}
+                        >
+                            Submit Offer
+                        </button>
+                    </div>
+                </form>
+
+                {offers.length > 0 && (
+                    <table className="mt-4 w-full text-left border">
+                        <thead>
+                            <tr className="bg-gray-100">
+                                <th className="p-2">Description</th>
+                                <th className="p-2">Partner</th>
+                                <th className="p-2">File</th>
+                                <th className="p-2">Submitted At</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {offers.map(offer => (
+                                <tr key={offer.id} className="border-t">
+                                    <td className="p-2">{offer.description}</td>
+                                    <td className="p-2">{offer.matched_partner_id}</td>
+                                    <td className="p-2">
+                                        {offer.documents && offer.documents[0] && (
+                                            <a href={`/storage/${offer.documents[0].path}`} className="text-blue-600 underline">
+                                                {offer.documents[0].name}
+                                            </a>
+                                        )}
+                                    </td>
+                                    <td className="p-2">{new Date(offer.created_at).toLocaleDateString()}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                )}
             </div>
         </section>
 

--- a/resources/js/Pages/Request/Show.tsx
+++ b/resources/js/Pages/Request/Show.tsx
@@ -1,7 +1,8 @@
 import { Head, usePage, Link } from '@inertiajs/react';
 import FrontendLayout from '@/Layouts/FrontendLayout';
-import { OCDRequest, OCDRequestGrid, DocumentList } from '@/types';
+import { OCDRequest, OCDRequestGrid, DocumentList, RequestOfferList } from '@/types';
 import AttachementsSection from '@/Pages/Request/Components/AttachementsSection';
+import OfferSection from '@/Pages/Request/Components/OfferSection';
 import RequestDetailsSection from '@/Pages/Request/Components/RequestDetailsSection';
 
 
@@ -9,6 +10,7 @@ export default function ShowRequest() {
   const OcdRequest = usePage().props.request as OCDRequest;
   const RequestPageDetails = usePage().props.requestDetail as OCDRequestGrid;
   const documents = usePage().props.documents as DocumentList;
+  const offers = usePage().props.offers as RequestOfferList;
 
   return (
     <FrontendLayout>
@@ -16,6 +18,7 @@ export default function ShowRequest() {
 
       <RequestDetailsSection OcdRequest={OcdRequest} />
       <AttachementsSection OcdRequest={OcdRequest} documents={documents} />
+      <OfferSection OcdRequest={OcdRequest} offers={offers} />
 
       {/* Separator */}
       <div className="border-t border-gray-200 my-6" />

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -79,6 +79,19 @@ export interface Document {
 
 export type DocumentList = Document[];
 
+export interface RequestOffer {
+    id: number;
+    description: string;
+    matched_partner_id: number;
+    request_id: number;
+    status: number;
+    created_at: string;
+    updated_at: string;
+    documents?: Document[];
+}
+
+export type RequestOfferList = RequestOffer[];
+
 export interface OCDRequest {
     id: string;
     type: string;
@@ -184,4 +197,9 @@ export interface AttachementsProps {
     OcdRequest: OcdRequest;
     canEdit?: boolean;
     documents?: Document[];
+}
+
+export interface OfferProps {
+    OcdRequest: OcdRequest;
+    offers: RequestOfferList;
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -67,6 +67,8 @@ Route::middleware(['auth', 'role:partner'])->group(function () {
     Route::get('request/list', [OcdRequestController::class, 'list'])->name('partner.request.list');
     Route::get('opportunity/edit/{id}', [OcdOpportunityController::class, 'edit'])->name('opportunity.edit');
     Route::get('request/matchedrequests', [OcdRequestController::class, 'matchedRequest'])->name('partner.request.matchedrequests');
+
+    Route::post('request/{request}/offer', [\App\Http\Controllers\RequestOfferController::class, 'store'])->name('partner.request.offer.store');
 });
 
 // Route::middleware(['auth', 'role:administrator'])->prefix('admin')->group(function () {


### PR DESCRIPTION
## Summary
- allow partners to submit offers with a description, partner id and PDF
- record uploaded offer documents
- expose offers in request details
- show submitted offers in the UI

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68493ab876ec832eb4449e902dea213f