### PR TITLE
Enable deleting draft requests

### DIFF
--- a/app/Http/Controllers/OcdRequestController.php
+++ b/app/Http/Controllers/OcdRequestController.php
@@ -39,7 +39,7 @@ class OcdRequestController extends Controller
             ],
             'grid.actions' => [
                 'canEdit' => true,
-                'canDelete' => false,
+                'canDelete' => true,
                 'canView' => true,
                 'canCreate' => true,
             ],
@@ -245,6 +245,23 @@ class OcdRequestController extends Controller
      */
     public function destroy(Request $request)
     {
-        //
+        $ocdRequestId = (int) $request->route('id');
+        $ocdRequest = OCDRequest::with('status')->find($ocdRequestId);
+
+        if (!$ocdRequest) {
+            return response()->json(['error' => 'Request not found'], 404);
+        }
+
+        if ($ocdRequest->user_id !== $request->user()->id) {
+            return response()->json(['error' => 'Forbidden'], 403);
+        }
+
+        if ($ocdRequest->status->status_code !== 'draft') {
+            return response()->json(['error' => 'Only draft requests can be deleted'], 422);
+        }
+
+        $ocdRequest->delete();
+
+        return response()->json(['message' => 'Request deleted successfully']);
     }
 }

--- a/resources/js/Pages/Request/List.tsx
+++ b/resources/js/Pages/Request/List.tsx
@@ -36,6 +36,16 @@ export default function RequestsList() {
                 ));
             });
     };
+
+    const handleDelete = (id: string) => {
+        if (!confirm('Are you sure you want to delete this request?')) {
+            return;
+        }
+        axios.delete(route('user.request.destroy', id))
+            .then(() => {
+                setRequestList(prev => prev.filter(req => req.id !== id));
+            });
+    };
     const titleBodyTemplate = (rowData: OCDRequest) => rowData.request_data.capacity_development_title ?? 'N/A';
     const submissionDateTemplate = (rowData: OCDRequest) => new Date(rowData.created_at).toLocaleDateString();
 
@@ -49,6 +59,15 @@ export default function RequestsList() {
                     <i className="pi pi-pencil mr-1" aria-hidden="true" />
                     Edit
                 </Link>
+            )}
+            {grid.actions.canDelete && rowData.status.status_code === 'draft' && (
+                <button
+                    onClick={() => handleDelete(rowData.id)}
+                    className="flex items-center text-red-600 hover:text-red-800"
+                >
+                    <i className="pi pi-trash mr-1" aria-hidden="true" />
+                    Delete
+                </button>
             )}
             {grid.actions.canView && (
                 <Link

--- a/routes/web.php
+++ b/routes/web.php
@@ -45,6 +45,7 @@ Route::middleware(['auth', 'role:user'])->group(function () {
     Route::post('user/request/submit/{mode?}', [OcdRequestController::class, 'submit'])->name('user.request.submit');
     Route::patch('user/request/{id}/status', [OcdRequestController::class, 'updateStatus'])->name('user.request.status');
     Route::post('user/request/{request}/document', [\App\Http\Controllers\DocumentController::class, 'store'])->name('user.request.document.store');
+    Route::delete('user/request/{id}', [OcdRequestController::class, 'destroy'])->name('user.request.destroy');
     Route::get('user/opportunity/list', [UserOpportunityController::class, 'list'])->name('user.opportunity.list');
     Route::get('user/opportunity/show/{id}', [UserOpportunityController::class, 'show'])->name('user.opportunity.show');
 });


### PR DESCRIPTION
## Summary
- allow deleting requests when viewing personal list
- expose route for delete request
- support Delete action on request list table

## Testing
- `npm run build` *(fails: React/TypeScript dependencies missing)*
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849f6b561d8832eb792977b5a608c37