### PR TITLE
Add document actions

### DIFF
--- a/app/Http/Controllers/DocumentController.php
+++ b/app/Http/Controllers/DocumentController.php
@@ -32,4 +32,17 @@ class DocumentController extends Controller
 
         return back();
     }
+
+    public function destroy(Document $document)
+    {
+        Storage::disk('public')->delete($document->path);
+        $document->delete();
+
+        return back();
+    }
+
+    public function download(Document $document)
+    {
+        return Storage::disk('public')->download($document->path, $document->name);
+    }
 }

--- a/resources/js/Pages/Request/Components/AttachementsSection.tsx
+++ b/resources/js/Pages/Request/Components/AttachementsSection.tsx
@@ -1,13 +1,21 @@
-import { Head, usePage, Link, useForm } from '@inertiajs/react';
-import type { Auth } from '@/types';
+import { Head, usePage, useForm } from '@inertiajs/react';
+import type { Auth, Document } from '@/types';
 import { AttachementsProps } from '@/types';
+import React, { useState } from 'react';
+import axios from 'axios';
 
 export default function AttachementsSection({ OcdRequest, canEdit = false, documents = [] }: AttachementsProps) {
     const { auth } = usePage<{ auth: Auth }>().props
+    const [documentList, setDocumentList] = useState<Document[]>(documents);
     const form = useForm<{ file: File | null; document_type: string }>({
         file: null,
         document_type: 'financial_breakdown_report',
     });
+    const handleDelete = (id: number) => {
+        axios.delete(route('user.document.destroy', id)).then(() => {
+            setDocumentList(prev => prev.filter(d => d.id !== id));
+        });
+    };
     return (
         <section id="attachements" className='my-8'>
             <div className="grid grid-cols-1">
@@ -51,25 +59,28 @@ export default function AttachementsSection({ OcdRequest, canEdit = false, docum
                         </button>
                     </div>
                 </form>
-                {documents.length > 0 && (
+                {documentList.length > 0 && (
                     <table className="mt-4 w-full text-left border">
                         <thead>
                             <tr className="bg-gray-100">
                                 <th className="p-2">Name</th>
                                 <th className="p-2">Type</th>
                                 <th className="p-2">Uploaded At</th>
+                                <th className="p-2">Actions</th>
                             </tr>
                         </thead>
                         <tbody>
-                            {documents.map(doc => (
+                            {documentList.map(doc => (
                                 <tr key={doc.id} className="border-t">
                                     <td className="p-2">
-                                        <a href={`/storage/${doc.path}`} className="text-blue-600 underline">
-                                            {doc.name}
-                                        </a>
+                                        {doc.name}
                                     </td>
                                     <td className="p-2">{doc.document_type}</td>
                                     <td className="p-2">{new Date(doc.created_at).toLocaleDateString()}</td>
+                                    <td className="p-2 space-x-2">
+                                        <a href={route('user.document.download', doc.id)} className="text-blue-600 underline">Download</a>
+                                        <button type="button" onClick={() => handleDelete(doc.id)} className="text-red-600 underline">Delete</button>
+                                    </td>
                                 </tr>
                             ))}
                         </tbody>

--- a/routes/web.php
+++ b/routes/web.php
@@ -45,6 +45,8 @@ Route::middleware(['auth', 'role:user'])->group(function () {
     Route::post('user/request/submit/{mode?}', [OcdRequestController::class, 'submit'])->name('user.request.submit');
     Route::patch('user/request/{id}/status', [OcdRequestController::class, 'updateStatus'])->name('user.request.status');
     Route::post('user/request/{request}/document', [\App\Http\Controllers\DocumentController::class, 'store'])->name('user.request.document.store');
+    Route::delete('user/document/{document}', [\App\Http\Controllers\DocumentController::class, 'destroy'])->name('user.document.destroy');
+    Route::get('user/document/{document}/download', [\App\Http\Controllers\DocumentController::class, 'download'])->name('user.document.download');
     Route::get('user/opportunity/list', [UserOpportunityController::class, 'list'])->name('user.opportunity.list');
     Route::get('user/opportunity/show/{id}', [UserOpportunityController::class, 'show'])->name('user.opportunity.show');
 });


### PR DESCRIPTION
## Summary
- allow downloading and deleting uploaded documents
- implement destroy and download in `DocumentController`
- expose new document routes
- update attachments section UI for download and delete

## Testing
- `composer test` *(fails: composer not installed)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a453ea364832e984768d0e3100803