### PR TITLE
Add delete support for opportunities

### DIFF
--- a/app/Http/Controllers/OcdOpportunityController.php
+++ b/app/Http/Controllers/OcdOpportunityController.php
@@ -173,4 +173,24 @@ class OcdOpportunityController extends Controller
             ]
         ]);
     }
+
+    public function destroy(Request $request, int $id)
+    {
+        $opportunity = Opportunity::find($id);
+        if (!$opportunity) {
+            return response()->json(['error' => 'Opportunity not found'], 404);
+        }
+
+        if ($opportunity->user_id !== $request->user()->id) {
+            return response()->json(['error' => 'Forbidden'], 403);
+        }
+
+        if ($opportunity->status !== OpportunityStatus::PENDING_REVIEW) {
+            return response()->json(['error' => 'Only pending review opportunities can be deleted'], 422);
+        }
+
+        $opportunity->delete();
+
+        return response()->json(['message' => 'Opportunity deleted successfully']);
+    }
 }

--- a/resources/js/Pages/Opportunity/List.tsx
+++ b/resources/js/Pages/Opportunity/List.tsx
@@ -35,6 +35,16 @@ export default function OpportunitiesList() {
                 ));
             });
     };
+
+    const handleDelete = (id: string) => {
+        if (!confirm('Are you sure you want to delete this opportunity?')) {
+            return;
+        }
+        axios.delete(route('partner.opportunity.destroy', id))
+            .then(() => {
+                setOpportunityList(prev => prev.filter(op => op.id !== id));
+            });
+    };
     const titleBodyTemplate = (rowData: OCDOpportunity) => rowData.title ?? 'N/A';
     const ApplicationClosingDate = (rowData: OCDOpportunity) => new Date(rowData.closing_date).toLocaleDateString();
     const statusBodyTemplate = (rowData: OCDOpportunity) => {
@@ -93,6 +103,16 @@ export default function OpportunitiesList() {
                     <i className="pi pi-pencil mr-1" aria-hidden="true" />
                     Edit
                 </Link>
+            )}
+
+            {rowData.can_edit && (
+                <button
+                    onClick={() => handleDelete(rowData.id)}
+                    className="flex items-center text-red-600 hover:text-red-800"
+                >
+                    <i className="pi pi-trash mr-1" aria-hidden="true" />
+                    Delete
+                </button>
             )}
 
             <Link

--- a/routes/web.php
+++ b/routes/web.php
@@ -64,6 +64,7 @@ Route::middleware(['auth', 'role:partner'])->group(function () {
     Route::get('opportunity/browse', [OcdOpportunityController::class, 'list'])->name('opportunity.browse');
     Route::get('opportunity/show/{id}', [OcdOpportunityController::class, 'show'])->name('opportunity.show');
     Route::patch('opportunity/{id}/status', [OcdOpportunityController::class, 'updateStatus'])->name('partner.opportunity.status');
+    Route::delete('opportunity/{id}', [OcdOpportunityController::class, 'destroy'])->name('partner.opportunity.destroy');
     Route::get('request/list', [OcdRequestController::class, 'list'])->name('partner.request.list');
     Route::get('opportunity/edit/{id}', [OcdOpportunityController::class, 'edit'])->name('opportunity.edit');
     Route::get('request/matchedrequests', [OcdRequestController::class, 'matchedRequest'])->name('partner.request.matchedrequests');


### PR DESCRIPTION
## Summary
- enable deleting opportunities in router
- implement controller logic to delete opportunities
- add delete action to opportunity list page

## Testing
- `php artisan test` *(fails: `php` not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a92aa2078832eb4b4b9f2370f40c5