### PR TITLE
Add user blocking feature

### DIFF
--- a/app/Http/Controllers/Admin/UserRoleController.php
+++ b/app/Http/Controllers/Admin/UserRoleController.php
@@ -24,7 +24,7 @@ class UserRoleController extends Controller
                 ['name' => 'Dashboard', 'url' => route('dashboard')],
                 ['name' => 'Requests', 'url' => route('user.request.myrequests')],
             ],
-            'users' => User::with('roles')->get()->makeVisible('id'),
+            'users' => User::with('roles')->get()->makeVisible(['id','is_blocked']),
             'roles' => Role::all(),
         ]);
     }
@@ -41,6 +41,17 @@ class UserRoleController extends Controller
         return response()->json([
             'message' => 'Roles updated successfully',
             'roles' => $user->roles->pluck('name'),
+        ]);
+    }
+
+    public function toggleBlock(User $user)
+    {
+        $user->is_blocked = !$user->is_blocked;
+        $user->save();
+
+        return response()->json([
+            'message' => $user->is_blocked ? 'User blocked' : 'User unblocked',
+            'is_blocked' => $user->is_blocked,
         ]);
     }
 }

--- a/app/Http/Controllers/Auth/SessionController.php
+++ b/app/Http/Controllers/Auth/SessionController.php
@@ -67,6 +67,12 @@ class SessionController extends Controller
                 'city' => $oceanExpertProfile['city'],
             ]
         );
+
+        if ($user->is_blocked) {
+            throw ValidationException::withMessages([
+                'email' => 'Your account is blocked.',
+            ]);
+        }
         Auth::login($user, false);
         $request->session()->put('external_api_token', $token);
         $request->session()->regenerate();

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -30,6 +30,7 @@ class User extends Authenticatable
         'last_name',
         'country',
         'city',
+        'is_blocked',
     ];
 
     protected $appends = ['is_partner','is_admin'];
@@ -66,6 +67,7 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'is_blocked' => 'boolean',
         ];
     }
 

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -29,6 +29,7 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'is_blocked' => false,
         ];
     }
 

--- a/database/migrations/2025_06_01_000000_add_is_blocked_to_users_table.php
+++ b/database/migrations/2025_06_01_000000_add_is_blocked_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('is_blocked')->default(false)->after('remember_token');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('is_blocked');
+        });
+    }
+};

--- a/resources/js/Pages/Admin/User/List.tsx
+++ b/resources/js/Pages/Admin/User/List.tsx
@@ -8,6 +8,14 @@ export default function UserRolesList() {
     const users = usePage().props.users as UserWithRoles[];
     const roles = usePage().props.roles as Role[];
 
+    const [blocked, setBlocked] = useState<Record<number, boolean>>(() => {
+        const map: Record<number, boolean> = {};
+        users.forEach((u) => {
+            map[u.id] = u.is_blocked;
+        });
+        return map;
+    });
+
     const [userRoles, setUserRoles] = useState<Record<number, string[]>>(() => {
         const map: Record<number, string[]> = {};
         users.forEach((u) => {
@@ -27,6 +35,14 @@ export default function UserRolesList() {
         });
     };
 
+    const toggleBlock = (userId: number) => {
+        const current = blocked[userId];
+        setBlocked({ ...blocked, [userId]: !current });
+        axios.post(route('admin.users.block.toggle', userId)).catch(() => {
+            setBlocked({ ...blocked, [userId]: current });
+        });
+    };
+
     return (
         <FrontendLayout>
             <Head title="Manage User Roles" />
@@ -42,6 +58,7 @@ export default function UserRolesList() {
                                     {role.name}
                                 </th>
                             ))}
+                            <th className="px-4 py-2 text-left text-xl font-medium text-gray-500 uppercase">Blocked</th>
                         </tr>
                     </thead>
                     <tbody className="divide-y divide-gray-200">
@@ -59,6 +76,14 @@ export default function UserRolesList() {
                                         />
                                     </td>
                                 ))}
+                                <td className="px-4 py-2 text-center">
+                                    <button
+                                        className="text-blue-600 underline"
+                                        onClick={() => toggleBlock(user.id)}
+                                    >
+                                        {blocked[user.id] ? 'Unblock' : 'Block'}
+                                    </button>
+                                </td>
                             </tr>
                         ))}
                     </tbody>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -9,6 +9,7 @@ export interface User {
     email_verified_at?: string;
     is_partner: boolean;
     is_admin: boolean;
+    is_blocked: boolean;
 }
 
 export interface Role {

--- a/routes/web.php
+++ b/routes/web.php
@@ -73,6 +73,7 @@ Route::middleware(['auth', 'role:partner'])->group(function () {
 // Route::middleware(['auth', 'role:administrator'])->prefix('admin')->group(function () {
 Route::get('users', [UserRoleController::class, 'index'])->name('admin.users.index');
 Route::post('users/{user}/roles', [UserRoleController::class, 'update'])->name('admin.users.roles.update');
+Route::post('users/{user}/toggle-block', [UserRoleController::class, 'toggleBlock'])->name('admin.users.block.toggle');
 Route::post('request/{request}/offer', [RequestOfferController::class, 'store'])->name('admin.request.offer.store');
 // });
 


### PR DESCRIPTION
## Summary
- allow admins to block/unblock users
- blocked users cannot sign in
- show block status on user list
- store blocked flag on users

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852c9b81440832e85f8d65e31eab358