### PR TITLE
Add backend admin layout

### DIFF
--- a/resources/js/Components/AdminMenu.tsx
+++ b/resources/js/Components/AdminMenu.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Link } from '@inertiajs/react';
+
+const AdminMenu: React.FC = () => {
+  return (
+    <nav>
+      <ul className="space-y-2">
+        <li>
+          <Link className="text-firefly-700 hover:underline" href={route('admin.users.index')}>
+            Manage Users
+          </Link>
+        </li>
+      </ul>
+    </nav>
+  );
+};
+
+export default AdminMenu;

--- a/resources/js/Layouts/BackendLayout.tsx
+++ b/resources/js/Layouts/BackendLayout.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import Header from '@/Components/Header';
+import Footer from '@/Components/Footer';
+import Banner from '@/Components/Banner';
+import Userguide from '@/Components/UserGuide';
+import Breadcrumb from '@/Components/Breadcrumb';
+
+interface BackendLayoutProps {
+  menu: React.ReactNode;
+  children: React.ReactNode;
+}
+
+const BackendLayout: React.FC<BackendLayoutProps> = ({ menu, children }) => {
+  return (
+    <div className="min-h-screen flex flex-col bg-white text-gray-900">
+      <Header />
+      <Banner />
+      <Userguide />
+      <Breadcrumb />
+      <main className="flex-grow container mx-auto py-8">
+        <div className="container shadow rounded bg-white p-6 grid grid-cols-4 gap-6">
+          <aside className="col-span-1">
+            {menu}
+          </aside>
+          <section className="col-span-3">
+            {children}
+          </section>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default BackendLayout;

--- a/resources/js/Pages/Admin/User/List.tsx
+++ b/resources/js/Pages/Admin/User/List.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Head, usePage } from '@inertiajs/react';
-import FrontendLayout from '@/Layouts/FrontendLayout';
+import BackendLayout from '@/Layouts/BackendLayout';
+import AdminMenu from '@/Components/AdminMenu';
 import axios from 'axios';
 import { Role, UserWithRoles } from '@/types';
 
@@ -28,7 +29,7 @@ export default function UserRolesList() {
     };
 
     return (
-        <FrontendLayout>
+        <BackendLayout menu={<AdminMenu />}>
             <Head title="Manage User Roles" />
             <div className="overflow-x-auto">
                 <table className="min-w-full table-auto bg-white">
@@ -64,6 +65,6 @@ export default function UserRolesList() {
                     </tbody>
                 </table>
             </div>
-        </FrontendLayout>
+        </BackendLayout>
     );
 }


### PR DESCRIPTION
## Summary
- implement BackendLayout for future admin dashboard
- create minimal AdminMenu component
- update admin user list page to use BackendLayout

## Testing
- `npm run build` *(fails: cannot fetch packages, TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68550fa7985c832e95398238b8ecee10