### PR TITLE
Dynamic opportunity type options

### DIFF
--- a/app/Http/Controllers/OcdOpportunityController.php
+++ b/app/Http/Controllers/OcdOpportunityController.php
@@ -21,6 +21,7 @@ class OcdOpportunityController extends Controller
                 'description' => 'Create a new Opportunity to get started.',
                 'image' => '/assets/img/sidebar.png',
             ],
+            'opportunityTypes' => Opportunity::getTypeOptions(),
             'breadcrumbs' => [
                 ['name' => 'Home', 'url' => route('user.home')],
                 ['name' => 'Opportunities', 'url' => route('opportunity.list')],
@@ -176,6 +177,7 @@ class OcdOpportunityController extends Controller
                 'description' => 'Edit my Opportunity details here.',
                 'image' => '/assets/img/sidebar.png',
             ],
+            'opportunityTypes' => Opportunity::getTypeOptions(),
             'request' => $opportunity->toArray(),
             'breadcrumbs' => [
                 ['name' => 'Dashboard', 'url' => route('dashboard')],

--- a/app/Models/Opportunity.php
+++ b/app/Models/Opportunity.php
@@ -24,6 +24,30 @@ class Opportunity extends Model
         OpportunityStatus::PENDING_REVIEW->value => 'Pending Review',
     ];
 
+    /**
+     * Available opportunity types
+     */
+    const TYPE_OPTIONS = [
+        'training' => 'Training',
+        'onboarding-expeditions' => 'Onboarding Expeditions, Research & Training',
+        'fellowships' => 'Fellowships',
+        'internships-jobs' => 'Internships/Jobs',
+        'mentorships' => 'Mentorships',
+        'visiting-lecturers' => 'Visiting Lecturers/Scholars',
+        'travel-grants' => 'Travel Grants',
+        'awards' => 'Awards',
+        'research-funding' => 'Research Fundings, Grants & Scholarships',
+        'access-infrastructure' => 'Access to Infrastructure',
+        'ocean-data' => 'Ocean Data, Information and Documentation',
+        'networks-community' => 'Professional Networks & Community Building',
+        'ocean-literacy' => 'Ocean Literacy, Public Information and Communication',
+    ];
+
+    public static function getTypeOptions(): array
+    {
+        return self::TYPE_OPTIONS;
+    }
+
     protected $casts = [
         'status' => OpportunityStatus::class,
     ];

--- a/resources/js/Pages/Opportunity/Create.tsx
+++ b/resources/js/Pages/Opportunity/Create.tsx
@@ -1,7 +1,7 @@
 import { Head, useForm, usePage } from '@inertiajs/react';
 import React, { useEffect, useState } from 'react';
 import FrontendLayout from '@/Layouts/FrontendLayout';
-import { OCDOpportunity } from '@/types';
+import { OCDOpportunity, OpportunityTypeOptions } from '@/types';
 import TagsInput from '@/Components/TagsInput';
 import { router } from '@inertiajs/react'
 import { Tag } from 'react-tag-input';
@@ -20,6 +20,7 @@ import { countryOptions, regionOptions, oceanOptions, Option } from '@/data/loca
 
 export default function CreateOpportunity() {
     const OcdOpportunityData = usePage().props.request as OCDOpportunity;
+    const opportunityTypes = usePage().props.opportunityTypes as OpportunityTypeOptions;
 
     const { data, setData, post, processing, errors, reset, setError, clearErrors, setDefaults } = useForm({
         id: OcdOpportunityData?.id,
@@ -130,25 +131,14 @@ export default function CreateOpportunity() {
                         <p className="mt-1 text-base text-gray-500">Specify the type of your Opportunity</p>
                         <select
                             id="type"
-
                             className={getInputClass()}
                             value={data.type}
                             onChange={(e) => setData('type' as keyof typeof data, e.currentTarget.value)}
                         >
                             <option value="">— Select —</option>
-                            <option value="raining">Training</option>
-                            <option value="onboarding-expeditions">Onboarding Expeditions, Research & Training</option>
-                            <option value="fellowships">Fellowships</option>
-                            <option value="internships-jobs">Internships/Jobs</option>
-                            <option value="mentorships">Mentorships</option>
-                            <option value="visiting-lecturers">Visiting Lecturers/Scholars</option>
-                            <option value="travel-grants">Travel Grants</option>
-                            <option value="awards">Awards</option>
-                            <option value="research-funding">Research Fundings, Grants & Scholarships</option>
-                            <option value="access-infrastructure">Access to Infrastructure</option>
-                            <option value="ocean-data">Ocean Data, Information and Documentation</option>
-                            <option value="networks-community">Professional Networks & Community Building</option>
-                            <option value="ocean-literacy">Ocean Literacy, Public Information and Communication</option>
+                            {Object.entries(opportunityTypes).map(([value, label]) => (
+                                <option key={value} value={value}>{label}</option>
+                            ))}
                         </select>
                         {errors.type && (
                             <p className="text-red-600 text-base mt-1">{errors.type}</p>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -152,7 +152,7 @@ export type OCDRequestList = OCDRequest[];
 export interface OCDOpportunity {
     id: string;
     title: string;
-    type: string[];
+    type: string;
     closing_date: string;
     coverage_activity: string;
     implementation_location: string;
@@ -206,3 +206,5 @@ export interface OfferProps {
     OcdRequest: OcdRequest;
     OcdRequestOffer: RequestOffer;
 }
+
+export type OpportunityTypeOptions = Record<string, string>;


### PR DESCRIPTION
## Summary
- centralize opportunity type options in the `Opportunity` model
- expose opportunity type options in `OcdOpportunityController`
- use the dynamic options when rendering the opportunity form
- update TypeScript types

## Testing
- `npm run build` *(fails: cannot access npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_685b2aa1b2d4832ea87548c776f9c06e