### PR TITLE
Add basic admin notifications

### DIFF
--- a/app/Http/Controllers/Admin/NotificationController.php
+++ b/app/Http/Controllers/Admin/NotificationController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Notification;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class NotificationController extends Controller
+{
+    public function index(): Response
+    {
+        $notifications = Auth::user()->notifications()->latest()->get();
+
+        return Inertia::render('Admin/Notification/List', [
+            'title' => 'Notifications',
+            'notifications' => $notifications,
+            'breadcrumbs' => [
+                ['name' => 'Home', 'url' => route('user.home')],
+                ['name' => 'Notifications'],
+            ],
+        ]);
+    }
+
+    public function show(Notification $notification): Response
+    {
+        $this->authorizeNotification($notification);
+
+        return Inertia::render('Admin/Notification/Show', [
+            'title' => $notification->title,
+            'notification' => $notification,
+            'breadcrumbs' => [
+                ['name' => 'Home', 'url' => route('user.home')],
+                ['name' => 'Notifications', 'url' => route('admin.notifications.index')],
+                ['name' => $notification->title],
+            ],
+        ]);
+    }
+
+    public function markAsRead(Notification $notification)
+    {
+        $this->authorizeNotification($notification);
+        $notification->update(['is_read' => true]);
+
+        return redirect()->back();
+    }
+
+    private function authorizeNotification(Notification $notification): void
+    {
+        abort_unless($notification->user_id === Auth::id(), 403);
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -35,6 +35,7 @@ class HandleInertiaRequests extends Middleware
             'auth' => [
                 'user' => $request->user(),
             ],
+            'unread_notifications' => $request->user()?->notifications()->where('is_read', false)->count() ?? 0,
         ];
     }
 }

--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Notification extends Model
+{
+    protected $fillable = [
+        'title',
+        'description',
+        'is_read',
+        'user_id',
+    ];
+
+    protected $casts = [
+        'is_read' => 'boolean',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -10,6 +10,7 @@ use Spatie\Permission\Traits\HasRoles;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use App\Models\Request;
+use App\Models\Notification;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 
 class User extends Authenticatable
@@ -77,6 +78,11 @@ class User extends Authenticatable
     public function matched_request(): HasOne
     {
         return $this->hasOne(Request::class);
+    }
+
+    public function notifications(): HasMany
+    {
+        return $this->hasMany(Notification::class);
     }
 
 }

--- a/database/migrations/2025_06_12_000001_create_notifications_table.php
+++ b/database/migrations/2025_06_12_000001_create_notifications_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('notifications', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->string('title');
+            $table->text('description');
+            $table->boolean('is_read')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('notifications');
+    }
+};

--- a/resources/js/Components/AdminMenu.tsx
+++ b/resources/js/Components/AdminMenu.tsx
@@ -33,6 +33,27 @@ const AdminMenu: React.FC = () => {
                         {({ open }) => (
                             <>
                                 <Disclosure.Button className="flex w-full items-center justify-between rounded bg-gray-100 px-4 py-2 text-left font-semibold hover:bg-gray-200">
+                                    <span>Notifications</span>
+                                    <ChevronDown className={`h-4 w-4 transition-transform ${open ? 'rotate-180' : ''}`} />
+                                </Disclosure.Button>
+                                <Disclosure.Panel as="div" className="mt-2 pl-4">
+                                    <ul className="space-y-1">
+                                        <li>
+                                            <Link className="text-firefly-700 hover:underline" href={route('admin.notifications.index')}>
+                                                List Notifications
+                                            </Link>
+                                        </li>
+                                    </ul>
+                                </Disclosure.Panel>
+                            </>
+                        )}
+                    </Disclosure>
+                </li>
+                <li>
+                    <Disclosure>
+                        {({ open }) => (
+                            <>
+                                <Disclosure.Button className="flex w-full items-center justify-between rounded bg-gray-100 px-4 py-2 text-left font-semibold hover:bg-gray-200">
                                     <span>Users</span>
                                     <ChevronDown className={`h-4 w-4 transition-transform ${open ? 'rotate-180' : ''}`} />
                                 </Disclosure.Button>

--- a/resources/js/Components/UserNav.tsx
+++ b/resources/js/Components/UserNav.tsx
@@ -3,7 +3,7 @@ import { usePage, Link, useForm } from '@inertiajs/react';
 import { Auth, User } from '@/types';
 
 export default function UserDropdown() {
-    const { auth } = usePage<{ auth: Auth }>().props;
+    const { auth, unread_notifications } = usePage<{ auth: Auth; unread_notifications: number }>().props;
     const user = auth.user;
     const [open, setOpen] = useState(false);
     const ref = useRef<HTMLDivElement>(null);
@@ -54,6 +54,11 @@ export default function UserDropdown() {
                 >
                     <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
                 </svg>
+                {user.is_admin && unread_notifications > 0 && (
+                    <span className="ml-2 bg-red-600 text-white rounded-full px-2 text-xs">
+                        {unread_notifications}
+                    </span>
+                )}
             </button>
 
             {/* Dropdown Menu */}
@@ -86,13 +91,24 @@ export default function UserDropdown() {
                         My Opportunties List
                     </Link>
                     )}
-                    <Link
-                        href={route('admin.users.index')}
-                        className="block px-4 py-2 text-gray-700 hover:bg-gray-100"
-                        role="menuitem"
-                    >
-                        Manage User Roles
-                    </Link>
+                    {user.is_admin && (
+                        <>
+                            <Link
+                                href={route('admin.notifications.index')}
+                                className="block px-4 py-2 text-gray-700 hover:bg-gray-100"
+                                role="menuitem"
+                            >
+                                Notifications
+                            </Link>
+                            <Link
+                                href={route('admin.users.index')}
+                                className="block px-4 py-2 text-gray-700 hover:bg-gray-100"
+                                role="menuitem"
+                            >
+                                Manage User Roles
+                            </Link>
+                        </>
+                    )}
                     <form method="POST" onSubmit={handleSignOutFormSubmit}>
                         {/* Include CSRF token if needed */}
                         <button

--- a/resources/js/Pages/Admin/Notification/List.tsx
+++ b/resources/js/Pages/Admin/Notification/List.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Head, Link, usePage } from '@inertiajs/react';
+import BackendLayout from '@/Layouts/BackendLayout';
+import AdminMenu from '@/Components/AdminMenu';
+import axios from 'axios';
+import { NotificationList } from '@/types';
+
+export default function NotificationListPage() {
+    const notifications = usePage().props.notifications as NotificationList;
+    const [items, setItems] = React.useState(notifications);
+
+    const markAsRead = (id: number) => {
+        axios.patch(route('admin.notifications.read', id)).then(() => {
+            setItems(prev => prev.map(n => n.id === id ? { ...n, is_read: true } : n));
+        });
+    };
+
+    return (
+        <BackendLayout menu={<AdminMenu />}>
+            <Head title="Notifications" />
+            <div className="space-y-4">
+                {items.map(n => (
+                    <div key={n.id} className="border p-4 rounded bg-white flex justify-between items-start">
+                        <div>
+                            <Link href={route('admin.notifications.show', n.id)} className="font-semibold text-lg text-firefly-700 hover:underline">
+                                {n.title}
+                            </Link>
+                            <p className="text-sm text-gray-600">{new Date(n.created_at).toLocaleString()}</p>
+                        </div>
+                        {!n.is_read && (
+                            <button onClick={() => markAsRead(n.id)} className="text-sm text-blue-600 hover:underline">
+                                Mark as read
+                            </button>
+                        )}
+                    </div>
+                ))}
+                {items.length === 0 && <p>No notifications found.</p>}
+            </div>
+        </BackendLayout>
+    );
+}

--- a/resources/js/Pages/Admin/Notification/Show.tsx
+++ b/resources/js/Pages/Admin/Notification/Show.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Head, usePage } from '@inertiajs/react';
+import BackendLayout from '@/Layouts/BackendLayout';
+import AdminMenu from '@/Components/AdminMenu';
+import { Notification } from '@/types';
+
+export default function NotificationShow() {
+    const notification = usePage().props.notification as Notification;
+    return (
+        <BackendLayout menu={<AdminMenu />}>
+            <Head title={notification.title} />
+            <h1 className="text-2xl font-semibold mb-4">{notification.title}</h1>
+            <p className="mb-2 text-sm text-gray-600">{new Date(notification.created_at).toLocaleString()}</p>
+            <p>{notification.description}</p>
+        </BackendLayout>
+    );
+}

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -31,6 +31,8 @@ export interface SharedData {
     auth: Auth;
     ziggy: Config & { location: string };
 
+    unread_notifications?: number;
+
     [key: string]: unknown;
 }
 
@@ -206,5 +208,15 @@ export interface OfferProps {
     OcdRequest: OcdRequest;
     OcdRequestOffer: RequestOffer;
 }
+
+export interface Notification {
+    id: number;
+    title: string;
+    description: string;
+    is_read: boolean;
+    created_at: string;
+}
+
+export type NotificationList = Notification[];
 
 export type OpportunityTypeOptions = Record<string, string>;

--- a/routes/web.php
+++ b/routes/web.php
@@ -75,6 +75,9 @@ Route::middleware(['auth', 'role:partner'])->group(function () {
 Route::get('users', [UserRoleController::class, 'index'])->name('admin.users.index');
 Route::post('users/{user}/roles', [UserRoleController::class, 'update'])->name('admin.users.roles.update');
 Route::post('request/{request}/offer', [RequestOfferController::class, 'store'])->name('admin.request.offer.store');
+Route::get('notifications', [\App\Http\Controllers\Admin\NotificationController::class, 'index'])->name('admin.notifications.index');
+Route::get('notifications/{notification}', [\App\Http\Controllers\Admin\NotificationController::class, 'show'])->name('admin.notifications.show');
+Route::patch('notifications/{notification}/read', [\App\Http\Controllers\Admin\NotificationController::class, 'markAsRead'])->name('admin.notifications.read');
 // });
 
 


### PR DESCRIPTION
## Summary
- create Notification model and migration
- share unread notification count via middleware
- add Notification controller and routes
- show notification count in admin navigation
- add React pages for listing and viewing notifications
- update admin menu with notifications link

## Testing
- `composer test` *(fails: composer missing)*

------
https://chatgpt.com/codex/tasks/task_e_685be8949d74832e91eb9703088a2f38